### PR TITLE
Fix add proper HTTP error handling

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -38,6 +38,11 @@ module.exports = async () => {
   
     console.log(JSON.stringify(result, null, 2))
   } catch (error) {
+    console.error('Full details:')
+    console.error(error)
+
+    console.error()
+    console.error('Short explanation:')
     console.error(error.message)
     if (error.response) {
       console.error(await error.response.json())

--- a/src/cli.js
+++ b/src/cli.js
@@ -25,15 +25,24 @@ module.exports = async () => {
   const since = subDays(new Date(), argv.days).toISOString()
   const githubFetcher = createGithubFetcher({ accessToken: process.env.ACCESS_TOKEN })
 
-  const result = await repositories.reduce(async (result, repositoryPath) => {
-    return Object.assign(await result, {
-      [repositoryPath]: {
-        issues: await parseIssues({ githubFetcher, userBlacklist, repositoryPath, since, labels }),
-        pulls: await parsePulls({ githubFetcher, userBlacklist, repositoryPath, since }),
-        releases: await parseReleases({ githubFetcher, repositoryPath, since })
-      }
-    })
-  }, Promise.resolve({}))
+  try {
+    const result = await repositories.reduce(async (result, repositoryPath) => {
+      return Object.assign(await result, {
+        [repositoryPath]: {
+          issues: await parseIssues({ githubFetcher, userBlacklist, repositoryPath, since, labels }),
+          pulls: await parsePulls({ githubFetcher, userBlacklist, repositoryPath, since }),
+          releases: await parseReleases({ githubFetcher, repositoryPath, since })
+        }
+      })
+    }, Promise.resolve({}))
+  
+    console.log(JSON.stringify(result, null, 2))
+  } catch (error) {
+    console.error(error.message)
+    if (error.response) {
+      console.error(await error.response.json())
+    }
 
-  console.log(JSON.stringify(result, null, 2))
+    process.exit(1)
+  }
 }

--- a/src/createGithubFetcher.js
+++ b/src/createGithubFetcher.js
@@ -1,5 +1,16 @@
 const fetch = require('node-fetch')
 
+const createHttpError = response => {
+  const cloneResponse = response.clone()
+
+  let error = new Error(`Request failed with status code ${cloneResponse.status} - ${cloneResponse.statusText}`)
+  error.status = cloneResponse.status
+  error.url = cloneResponse.url
+  error.response = cloneResponse
+
+  return error
+}
+
 /**
  * Pass the url relative to 'https://api.github.com' with a trailing slash (e.g. /repos/author/repo/issues)
  * or an absolute URL (e.g. https://api.github.com/repos/author/repo/issues)
@@ -21,14 +32,20 @@ const fetch = require('node-fetch')
  * @returns {githubFetcher}
  */
 const createGithubFetcher = config => {
-  return (url, options = {}) => {
-    return fetch(url.startsWith('/') ? `https://api.github.com${url}` : url, {
+  return async (url, options = {}) => {
+    const response = await fetch(url.startsWith('/') ? `https://api.github.com${url}` : url, {
       headers: config.accessToken !== void 0
         ? { 'Authorization': `token ${config.accessToken}` }
         : {},
       ...config.fetchOptions,
       ...options
     })
+
+    if (!response.ok) {
+      throw createHttpError(response)
+    }
+
+    return response
   }
 }
 


### PR DESCRIPTION
Network errors weren't being handled correctly, the flow wasn't getting changed and assuming the responses were containing the correct result instead of the error information. This was resulting in meaningless errors. Fixed this and possibly other errors by adding general and HTTP error handling for the CLI.

Closes #4.