### PR TITLE
feat: Added commit count parsing feature

### DIFF
--- a/config.json
+++ b/config.json
@@ -45,5 +45,8 @@
     "smolinari",
     "webnoob",
     "TobyMosque"
+  ],
+  "commitCountBlacklist": [
+    "dependabot-preview[bot]"
   ]
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@ require('dotenv').config()
 const yargs = require('yargs')
 const { subDays } = require('date-fns')
 
-const { parseIssues, parsePulls, parseReleases } = require('./parse')
+const { parseIssues, parsePulls, parseReleases, parseCommitCounts } = require('./parse')
 const { createGithubFetcher } = require('./createGithubFetcher')
 
 const config = require('../config.json')
@@ -31,11 +31,12 @@ module.exports = async () => {
         [repositoryPath]: {
           issues: await parseIssues({ githubFetcher, userBlacklist, repositoryPath, since, labels }),
           pulls: await parsePulls({ githubFetcher, userBlacklist, repositoryPath, since }),
-          releases: await parseReleases({ githubFetcher, repositoryPath, since })
+          releases: await parseReleases({ githubFetcher, repositoryPath, since }),
+          commitCounts: await parseCommitCounts({ githubFetcher, userBlacklist, repositoryPath, since })
         }
       })
     }, Promise.resolve({}))
-  
+
     console.log(JSON.stringify(result, null, 2))
   } catch (error) {
     console.error('Full details:')

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,7 +20,7 @@ module.exports = async () => {
     .alias('help', 'h')
     .argv
 
-  const { repositories, userBlacklist } = config
+  const { repositories, userBlacklist, commitCountBlacklist } = config
   const labels = ['bug']
   const since = subDays(new Date(), argv.days).toISOString()
   const githubFetcher = createGithubFetcher({ accessToken: process.env.ACCESS_TOKEN })
@@ -32,7 +32,7 @@ module.exports = async () => {
           issues: await parseIssues({ githubFetcher, userBlacklist, repositoryPath, since, labels }),
           pulls: await parsePulls({ githubFetcher, userBlacklist, repositoryPath, since }),
           releases: await parseReleases({ githubFetcher, repositoryPath, since }),
-          commitCounts: await parseCommitCounts({ githubFetcher, userBlacklist, repositoryPath, since })
+          commitCounts: await parseCommitCounts({ githubFetcher, importantUsers: userBlacklist, userBlacklist: commitCountBlacklist, repositoryPath, since })
         }
       })
     }, Promise.resolve({}))

--- a/src/parse.js
+++ b/src/parse.js
@@ -142,9 +142,15 @@ const parseCommitCounts = async ({ githubFetcher, userBlacklist = [], repository
       result[author].count++
 
       return result
-    }, {})
+    }, { '[others]': { author: '[others]', count: 0 } })
 
-  return Object.values(commitCounts)
+  const { '[others]': othersResults, ...authorsResult } = commitCounts
+  const sortedAuthorsResult = Object.values(authorsResult).sort((x, y) => y.count - x.count)
+
+  return [
+    othersResults,
+    ...sortedAuthorsResult
+  ]
 }
 
 const getUserName = async ({ githubFetcher, login }) => {

--- a/src/parse.js
+++ b/src/parse.js
@@ -146,15 +146,18 @@ const parseCommitCounts = async ({ githubFetcher, userBlacklist = [], importantU
       result[author].count++
 
       return result
-    }, { '[others]': { author: '[others]', count: 0 } })
+    }, {})
 
   const { '[others]': othersResults, ...authorsResult } = commitCounts
   const sortedAuthorsResult = Object.values(authorsResult).sort((x, y) => y.count - x.count)
 
-  return [
-    othersResults,
-    ...sortedAuthorsResult
-  ]
+  const finalResult = [...sortedAuthorsResult]
+
+  if (othersResults !== undefined) {
+    finalResult.unshift(othersResults)
+  }
+
+  return finalResult
 }
 
 const getUserName = async ({ githubFetcher, login }) => {


### PR DESCRIPTION
Closes #10.

I selected the author name for other contributors as `[others]` because `other` and `others` are valid Github usernames, but `[others]` is not a valid one.

Example output:
```json
{
  "commits": [
    {
      "author": "rstoenescu",
      "count": "125"
    },
    {
      "author": "pdanpdan",
      "count": "16"
    },
    {
      "author": "[others]",
      "count": "120"
    }
  ]
}
```